### PR TITLE
fix(tool-calls): 修改 larksuite 插件 #849

### DIFF
--- a/GetValuesRequest.java
+++ b/GetValuesRequest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.toolcalling.larksuite;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * @author huaiziqing
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record GetValuesRequest(@JsonProperty("spreadsheetToken") String spreadsheetToken,
+		@JsonProperty("range") String range) {
+
+}

--- a/LarkSuiteAutoConfiguration.java
+++ b/LarkSuiteAutoConfiguration.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.toolcalling.larksuite;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Description;
+
+/**
+ * @author 北极星
+ */
+@Configuration
+@EnableConfigurationProperties({ LarkSuiteProperties.class })
+@ConditionalOnClass({ LarkSuiteProperties.class })
+@ConditionalOnProperty(prefix = "spring.ai.alibaba.toolcalling.larksuite", name = "enabled", havingValue = "true",
+		matchIfMissing = true)
+public class LarkSuiteAutoConfiguration {
+
+	@Bean
+	@ConditionalOnMissingBean
+	@Description("It calls the document api to invoke a method to create a larksuite document")
+	public LarkSuiteCreateDocService larksuiteCreateDocFunction(LarkSuiteProperties properties) {
+		return new LarkSuiteCreateDocService(properties);
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	@Description("It runs a api to invoke a method to send message including group and single chat")
+	public LarkSuiteChatService larksuiteChatFunction(LarkSuiteProperties properties) {
+		return new LarkSuiteChatService(properties);
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	@Description("It calls the document api to invoke a method to create a larksuite sheet")
+	public LarkSuiteCreateSheetService larksuiteCreateSheetFunction(LarkSuiteProperties properties) {
+		return new LarkSuiteCreateSheetService(properties);
+	}
+
+}

--- a/ValuesAppendResp.java
+++ b/ValuesAppendResp.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.toolcalling.larksuite.param.resp;
+
+import com.lark.oapi.core.response.BaseResponse;
+
+/**
+ * @author NewGK
+ * @author huaiziqing
+ */
+
+public class ValuesAppendResp extends BaseResponse<ValuesAppendRespBody> {
+
+	private String requestId;
+
+	public ValuesAppendResp() {
+		super();
+	}
+
+	public String getSpreadsheetToken() {
+		ValuesAppendRespBody data = getData();
+		if (data == null) {
+			throw new IllegalStateException("Data is null");
+		}
+		return data.spreadsheetToken();
+	}
+
+	public ValuesAppendRespBodyUpdates getUpdates() {
+		ValuesAppendRespBody data = getData();
+		if (data == null || data.updates() == null) {
+			throw new IllegalStateException("Updates data is null");
+		}
+		return data.updates();
+	}
+
+	@Override
+	public String getRequestId() {
+		return requestId;
+	}
+
+	public void setRequestId(String requestId) {
+		this.requestId = requestId;
+	}
+
+	@Override
+	public String toString() {
+		return "ValuesAppendResp{" + "code=" + getCode() + ", msg='" + getMsg() + '\'' + ", spreadsheetToken='"
+				+ getSpreadsheetToken() + '\'' + ", updates=" + getUpdates() + '}';
+	}
+
+	public static class Builder {
+
+		private final ValuesAppendResp instance = new ValuesAppendResp();
+
+		public Builder code(int code) {
+			instance.setCode(code);
+			return this;
+		}
+
+		public Builder msg(String msg) {
+			instance.setMsg(msg);
+			return this;
+		}
+
+		public Builder requestId(String requestId) {
+			instance.setRequestId(requestId);
+			return this;
+		}
+
+		public Builder data(ValuesAppendRespBody data) {
+			instance.setData(data);
+			return this;
+		}
+
+		public ValuesAppendResp build() {
+			return instance;
+		}
+
+	}
+
+}

--- a/ValuesAppendRespBody.java
+++ b/ValuesAppendRespBody.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.toolcalling.larksuite.param.resp;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * @author NewGK
+ * @author huaiziqing
+ */
+
+public record ValuesAppendRespBody(int revision, String spreadsheetToken, String tableRange,
+		ValuesAppendRespBodyUpdates updates) {
+
+	@JsonCreator
+	public ValuesAppendRespBody(@JsonProperty("revision") int revision,
+			@JsonProperty("spreadsheetToken") String spreadsheetToken, @JsonProperty("tableRange") String tableRange,
+			@JsonProperty("updates") ValuesAppendRespBodyUpdates updates) {
+		this.revision = revision;
+		this.spreadsheetToken = spreadsheetToken;
+		this.tableRange = tableRange;
+		this.updates = updates;
+	}
+
+	@Override
+	public String toString() {
+		return "ValuesAppendRespBody{" + "revision=" + revision + ", spreadsheetToken='" + spreadsheetToken + '\''
+				+ ", tableRange='" + tableRange + '\'' + ", updates=" + updates + '}';
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (!(o instanceof ValuesAppendRespBody that))
+			return false;
+		return revision == that.revision && spreadsheetToken.equals(that.spreadsheetToken)
+				&& tableRange.equals(that.tableRange) && updates.equals(that.updates);
+	}
+
+	public static class Builder {
+
+		private int revision;
+
+		private String spreadsheetToken;
+
+		private String tableRange;
+
+		private ValuesAppendRespBodyUpdates updates;
+
+		public Builder revision(int revision) {
+			this.revision = revision;
+			return this;
+		}
+
+		public Builder spreadsheetToken(String spreadsheetToken) {
+			this.spreadsheetToken = spreadsheetToken;
+			return this;
+		}
+
+		public Builder tableRange(String tableRange) {
+			this.tableRange = tableRange;
+			return this;
+		}
+
+		public Builder updates(ValuesAppendRespBodyUpdates updates) {
+			this.updates = updates;
+			return this;
+		}
+
+		public ValuesAppendRespBody build() {
+			return new ValuesAppendRespBody(this.revision, this.spreadsheetToken, this.tableRange, this.updates);
+		}
+
+	}
+
+}

--- a/ValuesAppendRespBodyUpdates.java
+++ b/ValuesAppendRespBodyUpdates.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.toolcalling.larksuite.param.resp;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * @author NewGK
+ * @author huaiziqing
+ */
+
+public record ValuesAppendRespBodyUpdates(int revision, String spreadsheetToken, int updatedCells, int updatedColumns,
+		String updatedRange, int updatedRows) {
+
+	@JsonCreator
+	public ValuesAppendRespBodyUpdates(@JsonProperty("revision") int revision,
+			@JsonProperty("spreadsheetToken") String spreadsheetToken, @JsonProperty("updatedCells") int updatedCells,
+			@JsonProperty("updatedColumns") int updatedColumns, @JsonProperty("updatedRange") String updatedRange,
+			@JsonProperty("updatedRows") int updatedRows) {
+		this.revision = revision;
+		this.spreadsheetToken = spreadsheetToken;
+		this.updatedCells = updatedCells;
+		this.updatedColumns = updatedColumns;
+		this.updatedRange = updatedRange;
+		this.updatedRows = updatedRows;
+	}
+
+	@Override
+	public String toString() {
+		return "ValuesAppendRespBodyUpdates{" + "revision=" + revision + ", spreadsheetToken='" + spreadsheetToken
+				+ '\'' + ", updatedCells=" + updatedCells + ", updatedColumns=" + updatedColumns + ", updatedRange='"
+				+ updatedRange + '\'' + ", updatedRows=" + updatedRows + '}';
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (!(o instanceof ValuesAppendRespBodyUpdates that))
+			return false;
+		return revision == that.revision && updatedCells == that.updatedCells && updatedColumns == that.updatedColumns
+				&& updatedRows == that.updatedRows && spreadsheetToken.equals(that.spreadsheetToken)
+				&& updatedRange.equals(that.updatedRange);
+	}
+
+	public static class Builder {
+
+		private int revision;
+
+		private String spreadsheetToken;
+
+		private int updatedCells;
+
+		private int updatedColumns;
+
+		private String updatedRange;
+
+		private int updatedRows;
+
+		public Builder revision(int revision) {
+			this.revision = revision;
+			return this;
+		}
+
+		public Builder spreadsheetToken(String spreadsheetToken) {
+			this.spreadsheetToken = spreadsheetToken;
+			return this;
+		}
+
+		public Builder updatedCells(int updatedCells) {
+			this.updatedCells = updatedCells;
+			return this;
+		}
+
+		public Builder updatedColumns(int updatedColumns) {
+			this.updatedColumns = updatedColumns;
+			return this;
+		}
+
+		public Builder updatedRange(String updatedRange) {
+			this.updatedRange = updatedRange;
+			return this;
+		}
+
+		public Builder updatedRows(int updatedRows) {
+			this.updatedRows = updatedRows;
+			return this;
+		}
+
+		public ValuesAppendRespBodyUpdates build() {
+			return new ValuesAppendRespBodyUpdates(this.revision, this.spreadsheetToken, this.updatedCells,
+					this.updatedColumns, this.updatedRange, this.updatedRows);
+		}
+
+	}
+
+}

--- a/ValuesGetResp.java
+++ b/ValuesGetResp.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2024-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.cloud.ai.toolcalling.larksuite.param.resp;
+
+import com.lark.oapi.core.response.BaseResponse;
+
+import java.util.List;
+
+/**
+ * 飞书 Value 获取数据响应结构
+ */
+public class ValuesGetResp extends BaseResponse<ValuesGetResp.ValuesGetRespBody> {
+
+	private String requestId;
+
+	public ValuesGetResp() {
+		super();
+	}
+
+	public String getSpreadsheetToken() {
+		return getData().getSpreadsheetToken();
+	}
+
+	public String getTableRange() {
+		return getData().getTableRange();
+	}
+
+	public List<List<String>> getValues() {
+		return getData().getValues();
+	}
+
+	@Override
+	public String getRequestId() {
+		return requestId;
+	}
+
+	public void setRequestId(String requestId) {
+		this.requestId = requestId;
+	}
+
+	public static class Builder {
+
+		private final ValuesGetResp instance = new ValuesGetResp();
+
+		public Builder code(int code) {
+			instance.setCode(code);
+			return this;
+		}
+
+		public Builder msg(String msg) {
+			instance.setMsg(msg);
+			return this;
+		}
+
+		public Builder requestId(String requestId) {
+			instance.setRequestId(requestId);
+			return this;
+		}
+
+		public Builder data(ValuesGetRespBody data) {
+			instance.setData(data);
+			return this;
+		}
+
+		public ValuesGetResp build() {
+			return instance;
+		}
+
+	}
+
+	public static class ValuesGetRespBody {
+
+		private final String spreadsheetToken;
+
+		private final String tableRange;
+
+		private final List<List<String>> values;
+
+		public ValuesGetRespBody(Builder builder) {
+			this.spreadsheetToken = builder.spreadsheetToken;
+			this.tableRange = builder.tableRange;
+			this.values = builder.values;
+		}
+
+		public String getSpreadsheetToken() {
+			return spreadsheetToken;
+		}
+
+		public String getTableRange() {
+			return tableRange;
+		}
+
+		public List<List<String>> getValues() {
+			return values;
+		}
+
+		public static class Builder {
+
+			private String spreadsheetToken;
+
+			private String tableRange;
+
+			private List<List<String>> values;
+
+			public Builder spreadsheetToken(String spreadsheetToken) {
+				this.spreadsheetToken = spreadsheetToken;
+				return this;
+			}
+
+			public Builder tableRange(String tableRange) {
+				this.tableRange = tableRange;
+				return this;
+			}
+
+			public Builder values(List<List<String>> values) {
+				this.values = values;
+				return this;
+			}
+
+			public ValuesGetRespBody build() {
+				return new ValuesGetRespBody(this);
+			}
+
+		}
+
+	}
+
+}


### PR DESCRIPTION
本次提交只提交了修改文件
1.ValuesAppendRespBodyUpdates 类
用途：封装飞书表格数据追加操作的更新详情信息。
包含字段：
revision: 表格版本号。
spreadsheetToken: 表格唯一标识。
updatedCells: 更新的单元格数量。
updatedColumns: 更新的列数。
updatedRange: 更新的范围
updatedRows: 更新的行数。
2.ValuesAppendRespBodyUpdates 类
用途：表示飞书表格数据追加接口返回的主体响应内容。
包含字段：
revision: 表格版本号。
spreadsheetToken: 表格唯一标识。
tableRange: 数据写入的范围。
updates: ValuesAppendRespBodyUpdates 对象，记录详细更新信息。

3.ValuesAppendResp 类
用途：封装飞书表格数据追加接口的完整响应结构。
继承关系：继承自 BaseResponse，用于封装通用字段和业务数据。
包含字段：
requestId: 请求的唯一 ID。
code: 响应码。
msg: 响应消息。
data: ValuesAppendRespBody 对象，包含具体的响应数据。


### Describe what this PR does / why we need it


### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
